### PR TITLE
PDEV-498: add pg_stat_statements to default extensions floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
-## [2.5.0-jmpicnic-pdev498] - 2026-05-14
+## [2.5.0] - 2026-05-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [2.5.0-jmpicnic-pdev498] - 2026-05-14
+
+### Added
+
+- `pg_stat_statements` joins `pg_trgm` and `btree_gin` in the default extensions floor.
+  The extension is now created in every application database the initializer provisions,
+  making slow-query observability data reachable without a disconnect/reconnect to the
+  admin database.
+  Cluster prerequisite: the Postgres cluster must include `pg_stat_statements` in its
+  `shared_preload_libraries` (Aurora parameter group + restart, or `postgres -c …` on
+  plain Postgres). If the prerequisite is missing the init container fails fast —
+  deliberately, to keep observability data from silently going dark on downstream
+  consumers. See Arda PDEV-498 for the motivating use case.
+
 ## [2.4.0] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,9 +30,15 @@ Keys and values are separated with a `=`. Comment lines, starting with a `#`, ar
 | database_owner          | yes      | Name of the database owner                                                                            |
 | database_owner_password | yes      | Password for the database owner                                                                       |
 | connection_limit        | no       | Initial connection count limit, defaults to 100                                                       |
-| extensions              | no       | Comma-separated names of Postgres extensions to create; `pg_trgm` and `btree_gin` are always included |
+| extensions              | no       | Comma-separated names of Postgres extensions to create; `pg_trgm`, `btree_gin`, and `pg_stat_statements` are always included |
 
 Mount the file at `/home/values.properties`.
+
+### Cluster prerequisite for `pg_stat_statements`
+
+The image always attempts to create the `pg_stat_statements` extension in the application database. This requires the Postgres cluster to have `pg_stat_statements` listed in its `shared_preload_libraries` (typically set via an Aurora DB-cluster parameter group + instance restart, or a `postgres -c shared_preload_libraries=pg_stat_statements` argument on plain Postgres).
+
+If the prerequisite is not satisfied, the init container fails with `ERROR: pg_stat_statements must be loaded via shared_preload_libraries` and the pod enters `Init:CrashLoopBackOff` until the cluster configuration is corrected. This is deliberate — the failure is bounded to at most one occurrence per cluster (once the preload is set, every subsequent initialization succeeds), and the fail-loud surface guarantees the observability data is actually available before downstream consumers start relying on it.
 
 ## .pgenv
 

--- a/src/main/docker/create.sql
+++ b/src/main/docker/create.sql
@@ -70,15 +70,16 @@ WHERE btrim(extension_name) <> ''
 -- allocated, so queries against the view error out with
 -- `pg_stat_statements must be loaded via shared_preload_libraries`.
 --
--- The explicit `SELECT count(*) ...` below exercises the view so the
+-- The bounded `PERFORM ... LIMIT 1` below exercises the view so the
 -- error surfaces at init time (fail-loud), instead of silently going
 -- dark until a downstream operator queries it. `ON_ERROR_STOP on` then
 -- aborts the init script and the pod enters `Init:CrashLoopBackOff`,
--- prompting cluster-config review.
+-- prompting cluster-config review. `LIMIT 1` keeps the check cheap on
+-- clusters with a large `pg_stat_statements.max`.
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
-        PERFORM count(*) FROM pg_stat_statements;
+        PERFORM 1 FROM pg_stat_statements LIMIT 1;
     END IF;
 END;
 $$;

--- a/src/main/docker/create.sql
+++ b/src/main/docker/create.sql
@@ -63,6 +63,26 @@ FROM regexp_split_to_table(:'extensions', ',') AS extension_name
 WHERE btrim(extension_name) <> ''
 \gexec
 
+-- Verify pg_stat_statements is functional, not just installed. On modern
+-- Postgres (16+), `CREATE EXTENSION pg_stat_statements` succeeds even
+-- when `shared_preload_libraries` is missing the entry — the schema
+-- objects get installed but the underlying shared-memory hash is never
+-- allocated, so queries against the view error out with
+-- `pg_stat_statements must be loaded via shared_preload_libraries`.
+--
+-- The explicit `SELECT count(*) ...` below exercises the view so the
+-- error surfaces at init time (fail-loud), instead of silently going
+-- dark until a downstream operator queries it. `ON_ERROR_STOP on` then
+-- aborts the init script and the pod enters `Init:CrashLoopBackOff`,
+-- prompting cluster-config review.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        PERFORM count(*) FROM pg_stat_statements;
+    END IF;
+END;
+$$;
+
 -- Revoke the ability to drop the database or create new users
 REVOKE CREATE ON DATABASE :"database_name" FROM :"database_owner";
 REVOKE CREATE ON DATABASE :"database_name" FROM :"database_role";

--- a/src/main/docker/entrypoint.sh
+++ b/src/main/docker/entrypoint.sh
@@ -36,7 +36,7 @@ chmod -f 0600 ${PGPASSFILE}
 readonly values=/home/values.properties
 normalized_extensions=
 for extension in $(
-    echo "pg_trgm,btree_gin,$(sed -n -e 's/^extensions=//p' "${values}")" |
+    echo "pg_trgm,btree_gin,pg_stat_statements,$(sed -n -e 's/^extensions=//p' "${values}")" |
     awk -F',' '{ for (i = 1; i <= NF; i++) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $i); if ($i != "") print $i } }' |
     sort -u \
   ); do

--- a/src/test/docker/compose.yaml
+++ b/src/test/docker/compose.yaml
@@ -3,9 +3,12 @@ name: integration-test
 services:
   postgres:
     image: postgres:16-alpine3.20
-    # `shared_preload_libraries=pg_stat_statements` is required so that
-    # CREATE EXTENSION pg_stat_statements succeeds — the initializer
-    # now always tries to create this extension (see CHANGELOG 2.5.0).
+    # `shared_preload_libraries=pg_stat_statements` is required for the
+    # initializer's verify query against pg_stat_statements to succeed.
+    # CREATE EXTENSION itself works without the preload on PG 16+ (the
+    # schema objects install fine), but querying the view fails until
+    # the library is preloaded — and the initializer deliberately fails
+    # loud in that case (see CHANGELOG 2.5.0).
     command:
       - "postgres"
       - "-c"

--- a/src/test/docker/compose.yaml
+++ b/src/test/docker/compose.yaml
@@ -3,6 +3,26 @@ name: integration-test
 services:
   postgres:
     image: postgres:16-alpine3.20
+    # `shared_preload_libraries=pg_stat_statements` is required so that
+    # CREATE EXTENSION pg_stat_statements succeeds — the initializer
+    # now always tries to create this extension (see CHANGELOG 2.5.0).
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_preload_libraries=pg_stat_statements"
+    environment:
+      POSTGRES_USER: "main-user"
+      POSTGRES_PASSWORD: "main\\user:password"
+    healthcheck:
+      test: "pg_isready -U main-user"
+      interval: 1s
+      start_period: 5s
+      retries: 10
+  # Mirror of `postgres` *without* the shared_preload_libraries override,
+  # used by `sut_no_preload` to verify the initializer fails-loud when
+  # the cluster prerequisite for pg_stat_statements is missing.
+  postgres_no_preload:
+    image: postgres:16-alpine3.20
     environment:
       POSTGRES_USER: "main-user"
       POSTGRES_PASSWORD: "main\\user:password"
@@ -95,6 +115,20 @@ services:
     command:
       - "down"
       - "postgresql://postgres:5432"
+    volumes:
+      - "${PWD}/src/test/docker/pgpass:/home/.pgpass"
+      - "${PWD}/src/test/docker/values_minimal.properties:/home/values.properties"
+  # Targets postgres_no_preload (without shared_preload_libraries) — the
+  # initializer is expected to fail loud here. `tests.sh` inverts the
+  # exit-code expectation for this service.
+  sut_no_preload:
+    image: "arda-cards/postgres-database-initializer"
+    build:
+      context: "${PWD}/src/main/docker"
+    depends_on:
+      postgres_no_preload:
+        condition: service_healthy
+    command: "postgresql://postgres_no_preload:5432"
     volumes:
       - "${PWD}/src/test/docker/pgpass:/home/.pgpass"
       - "${PWD}/src/test/docker/values_minimal.properties:/home/values.properties"

--- a/src/test/docker/test.sql
+++ b/src/test/docker/test.sql
@@ -37,3 +37,20 @@ BEGIN
     END IF;
 END;
 $$;
+
+-- Default extensions floor: every database the initializer provisions
+-- gets pg_trgm, btree_gin, and pg_stat_statements created in it.
+SELECT * FROM pg_extension;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm') THEN
+        RAISE EXCEPTION 'Extension pg_trgm was not created';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'btree_gin') THEN
+        RAISE EXCEPTION 'Extension btree_gin was not created';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        RAISE EXCEPTION 'Extension pg_stat_statements was not created';
+    END IF;
+END;
+$$;

--- a/src/test/docker/test_all.sql
+++ b/src/test/docker/test_all.sql
@@ -27,5 +27,8 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'btree_gist') THEN
         RAISE EXCEPTION 'Extension btree_gist was not created';
     END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        RAISE EXCEPTION 'Extension pg_stat_statements was not created';
+    END IF;
 END;
 $$;

--- a/tests.sh
+++ b/tests.sh
@@ -25,4 +25,15 @@ run docker compose -f src/test/docker/compose.yaml up --exit-code-from tester_al
 run docker compose -f src/test/docker/compose.yaml up --exit-code-from teardown teardown
 run docker compose -f src/test/docker/compose.yaml up --exit-code-from teardown_empty teardown_empty
 
+# Fail-loud verification: when shared_preload_libraries does not include
+# pg_stat_statements, the initializer must exit non-zero (the default
+# extensions floor includes pg_stat_statements and CREATE EXTENSION
+# errors out without the preload).
+echo ">>> Fail-loud verification (sut_no_preload — expected to exit non-zero)"
+if docker compose -f src/test/docker/compose.yaml up --exit-code-from sut_no_preload sut_no_preload; then
+  echo "FAIL: sut_no_preload exited 0 but was expected to fail (pg_stat_statements not preloaded)"
+  exit 1
+fi
+echo ">>> PASS: sut_no_preload exited non-zero as expected"
+
 echo ">>> SUCCESS <<<"

--- a/tests.sh
+++ b/tests.sh
@@ -26,14 +26,29 @@ run docker compose -f src/test/docker/compose.yaml up --exit-code-from teardown 
 run docker compose -f src/test/docker/compose.yaml up --exit-code-from teardown_empty teardown_empty
 
 # Fail-loud verification: when shared_preload_libraries does not include
-# pg_stat_statements, the initializer must exit non-zero (the default
-# extensions floor includes pg_stat_statements and CREATE EXTENSION
-# errors out without the preload).
-echo ">>> Fail-loud verification (sut_no_preload — expected to exit non-zero)"
-if docker compose -f src/test/docker/compose.yaml up --exit-code-from sut_no_preload sut_no_preload; then
+# pg_stat_statements, the initializer must exit non-zero AND the failure
+# must surface the specific preload-missing Postgres error. CREATE
+# EXTENSION itself succeeds on PG 16+ — the failure comes from the
+# verify query in create.sql that queries pg_stat_statements. Asserting
+# the error string (not just a non-zero exit) prevents an unrelated
+# build / dependency / daemon failure from masquerading as a passing
+# negative test.
+echo ">>> Fail-loud verification (sut_no_preload — expected preload-missing error)"
+no_preload_log="$(mktemp)"
+if docker compose -f src/test/docker/compose.yaml up --exit-code-from sut_no_preload sut_no_preload >"$no_preload_log" 2>&1; then
   echo "FAIL: sut_no_preload exited 0 but was expected to fail (pg_stat_statements not preloaded)"
+  cat "$no_preload_log"
+  rm -f "$no_preload_log"
   exit 1
 fi
-echo ">>> PASS: sut_no_preload exited non-zero as expected"
+if ! grep -q "pg_stat_statements must be loaded via shared_preload_libraries" "$no_preload_log"; then
+  echo "FAIL: sut_no_preload exited non-zero but did not surface the expected preload-missing error"
+  echo "      Expected substring: 'pg_stat_statements must be loaded via shared_preload_libraries'"
+  cat "$no_preload_log"
+  rm -f "$no_preload_log"
+  exit 1
+fi
+rm -f "$no_preload_log"
+echo ">>> PASS: sut_no_preload failed with the expected preload-missing error"
 
 echo ">>> SUCCESS <<<"


### PR DESCRIPTION
>[!Caution]
> This PR depends on https://github.com/Arda-cards/infrastructure/pull/456 merging and deploying its changes, including the Db upgrade.

## Summary

`pg_stat_statements` joins `pg_trgm` and `btree_gin` in the image's always-on extensions floor. Every application database the initializer provisions now gets the extension created in it, so slow-query observability data (cluster-wide tracking via `shared_preload_libraries`) is reachable from the app DB — no disconnect/reconnect to the admin DB needed.

Resolves [PDEV-498](https://linear.app/ardacards/issue/PDEV-498/postgres-database-initializer-enable-pg-stat-statements-extension) (sub-issue of [PDEV-479](https://linear.app/ardacards/issue/PDEV-479/review-prod-aurora-db-configuration-sizing-observability-and-slow), unblocks [PDEV-490](https://linear.app/ardacards/issue/PDEV-490/operations-performance-improvements)).

Closes PDEV-498

## What changed

- `src/main/docker/entrypoint.sh` — one-line edit: `pg_stat_statements` added to the default extensions floor.
- `src/main/docker/create.sql` — new `DO` block immediately after the extension-creation `\gexec`. Runs `PERFORM count(*) FROM pg_stat_statements` so the "must be loaded via shared_preload_libraries" error surfaces at *init* time (fail-loud) instead of at first *query* time (silent). See "Why the verify-query block" below.
- `README.md` — `values.properties` table reflects the new floor member; new "Cluster prerequisite for `pg_stat_statements`" subsection.
- `CHANGELOG.md` — release entry `2.5.0` under `Added`.
- `src/test/docker/compose.yaml` — happy-path `postgres` service now starts with `command: ['postgres', '-c', 'shared_preload_libraries=pg_stat_statements']`; new `postgres_no_preload` + `sut_no_preload` services exercise the fail-loud path.
- `src/test/docker/test.sql` / `test_all.sql` — assert `pg_stat_statements` present in `pg_extension` inside the app DB alongside the existing extension assertions.
- `tests.sh` — appended a fail-loud verification step that asserts `sut_no_preload` exits non-zero.

## Why the verify-query block

The original design assumed `CREATE EXTENSION pg_stat_statements` would itself error when `shared_preload_libraries` is missing. Empirical check during implementation against `postgres:16-alpine3.20` proved otherwise: in modern Postgres, the `CREATE` succeeds, the schema objects install, but the shared-memory hash is never allocated. The error surfaces only when something queries the view.

That silent-success would let an Aurora cluster ship with a working initializer but an *unqueryable* `pg_stat_statements`, and PDEV-490's authors would discover the gap weeks later when their slow-query analysis returns zero rows. The verify-query block (`PERFORM count(*) FROM pg_stat_statements` guarded by an `EXISTS` check on `pg_extension`) collapses the failure window to the init container's first run — exactly the "fail-loud, dev-catches-it-first, low blast radius" design intent from PDEV-498.

## Coordination with PDEV-479

PDEV-479 lands the Aurora DB-cluster parameter group with `shared_preload_libraries=pg_stat_statements`. **Apply that before any chart that references this image's new release deploys to a cluster**, otherwise the operations pod enters `Init:CrashLoopBackOff` until the cluster is reconfigured.

The crash-loop is fully recoverable — apply the parameter group, K8s retries the init container, the verify-query passes, the pod starts. The hard-fail behaviour is deliberate (per the design note in `_docs/analysis/db-init.md`).

## Test plan

- [x] `make build` — clean docker build.
- [x] `./tests.sh` — full test suite including new fail-loud verification step. All seven existing tests pass, plus the new `sut_no_preload` assertion (init container exits non-zero with `pg_stat_statements must be loaded via shared_preload_libraries`).
- [ ] CI green.
- [ ] Manual cluster verification on Alpha002-dev once PDEV-479 lands the parameter group and the new image tag is consumed by the operations chart.

## Out of scope

- Cluster-level parameter group (PDEV-479).
- `pg_stat_statements.track` / `.max` tuning (PDEV-479).
- Operations chart init-container image-tag bump (separate release-pipeline step).
- `CREATE EXTENSION` in the `postgres` admin DB (deliberately not pursued — every app DB gets the view via the existing floor mechanism, which is the right surface for operators connecting to those DBs).

> [!note]
> Authored by Claude Opus 4.7 (1M context) for jmpicnic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
